### PR TITLE
KnownNat (n+1) |- KnownNat n

### DIFF
--- a/ghc-typelits-knownnat.cabal
+++ b/ghc-typelits-knownnat.cabal
@@ -74,13 +74,13 @@ library
                        TypeApplications
                        TypeOperators
   build-depends:       base                >= 4.9   && <4.10,
-                       containers          >= 0.5,
+                       containers          >= 0.5   && <0.6,
                        ghc                 >= 8.0.1 && <8.2,
                        ghc-tcplugins-extra >= 0.2
   hs-source-dirs:      src
   default-language:    Haskell2010
   if flag(deverror)
-    ghc-options:       -Wall
+    ghc-options:       -Wall -Werror
   else
     ghc-options:       -Wall
 
@@ -99,6 +99,4 @@ test-suite test-ghc-typelits-knownat
                        TypeApplications
                        TypeOperators
   if flag(deverror)
-    ghc-options:       -O0 -dcore-lint -ddump-tc-trace
-  else
-    ghc-options:       -ddump-tc-trace
+    ghc-options:       -O0 -dcore-lint

--- a/ghc-typelits-knownnat.cabal
+++ b/ghc-typelits-knownnat.cabal
@@ -74,12 +74,13 @@ library
                        TypeApplications
                        TypeOperators
   build-depends:       base                >= 4.9   && <4.10,
+                       containers          >= 0.5,
                        ghc                 >= 8.0.1 && <8.2,
                        ghc-tcplugins-extra >= 0.2
   hs-source-dirs:      src
   default-language:    Haskell2010
   if flag(deverror)
-    ghc-options:       -Wall -Werror
+    ghc-options:       -Wall
   else
     ghc-options:       -Wall
 
@@ -93,8 +94,11 @@ test-suite test-ghc-typelits-knownat
   hs-source-dirs:      tests
   default-language:    Haskell2010
   other-extensions:    DataKinds
+                       FlexibleContexts
                        ScopedTypeVariables
                        TypeApplications
                        TypeOperators
   if flag(deverror)
-    ghc-options:       -O0 -dcore-lint
+    ghc-options:       -O0 -dcore-lint -ddump-tc-trace
+  else
+    ghc-options:       -ddump-tc-trace

--- a/src/GHC/TypeLits/KnownNat.hs
+++ b/src/GHC/TypeLits/KnownNat.hs
@@ -25,7 +25,7 @@ module GHC.TypeLits.KnownNat () where
 
 import Data.Bits    (shiftL)
 import Data.Proxy   (Proxy (..))
-import GHC.TypeLits (KnownNat, Nat, type (+), type (*), type (^), natVal)
+import GHC.TypeLits (KnownNat, Nat, type (+), type (-), type (*), type (^), natVal)
 
 newtype SNatKn (n :: Nat) = SNatKn Integer
 
@@ -35,6 +35,13 @@ class KnownNatAdd (a :: Nat) (b :: Nat) where
 instance (KnownNat a, KnownNat b) => KnownNatAdd a b where
   natSingAdd = SNatKn (natVal (Proxy @ a) + natVal (Proxy @ b))
   {-# INLINE natSingAdd #-}
+
+class KnownNatSubtract (a :: Nat) (b :: Nat) where
+  natSingSubtract :: SNatKn (a - b)
+
+instance (KnownNat a, KnownNat b) => KnownNatSubtract a b where
+  natSingSubtract = SNatKn (natVal (Proxy @ a) - natVal (Proxy @ b))
+  {-# INLINE natSingSubtract #-}
 
 class KnownNatMul (a :: Nat) (b :: Nat) where
   natSingMul :: SNatKn (a * b)

--- a/src/GHC/TypeLits/KnownNat/Solver.hs
+++ b/src/GHC/TypeLits/KnownNat/Solver.hs
@@ -40,6 +40,7 @@ Pragma to the header of your file.
 
 -}
 
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TupleSections              #-}
 
@@ -47,11 +48,18 @@ Pragma to the header of your file.
 
 {-# OPTIONS_HADDOCK show-extensions #-}
 
+#if __GLASGOW_HASKELL__ < 801
+#define nonDetCmpType cmpType
+#endif
+
 module GHC.TypeLits.KnownNat.Solver (plugin) where
 
 -- external
 import Data.Coerce         (coerce)
 import Data.Maybe          (catMaybes,mapMaybe)
+import Data.List           (group, sort)
+import qualified Data.Set
+import Control.Arrow       ((&&&))
 import GHC.TcPluginM.Extra (lookupModule, lookupName, tracePlugin)
 
 -- GHC API
@@ -70,22 +78,54 @@ import TcEvidence (EvTerm (..), EvLit (EvNum), mkEvCast, mkTcSymCo, mkTcTransCo)
 import TcPluginM  (TcPluginM, tcLookupClass, getInstEnvs, zonkCt)
 import TcRnTypes  (Ct, CtEvidence (..), TcPlugin(..), TcPluginResult (..),
                    ctEvidence, ctEvPred, isWanted)
-import TcTypeNats (typeNatAddTyCon, typeNatMulTyCon, typeNatExpTyCon)
+import TcTypeNats (typeNatAddTyCon, typeNatSubTyCon, typeNatMulTyCon, typeNatExpTyCon)
 import Type       (PredTree (ClassPred), classifyPredType, dropForAlls, eqType,
-                   funResultTy, tyConAppTyCon_maybe, mkNumLitTy,
+                   nonDetCmpType, funResultTy, tyConAppTyCon_maybe, mkNumLitTy,
                    mkTyConApp)
 import TyCoRep    (Type (..), TyLit (..))
 import Var        (DFunId, EvVar)
 
+-- | Map to normalize additions
+type Pluses = Data.Set.Set KnOp
+
+pluses :: KnOp -> Pluses
+pluses = Data.Set.fromList . map products . group . constants . sort . getPluses
+  where products [p] = p
+        products ps@(p:_) = p `Mul` I (fromIntegral $ length ps)
+        constants (I a : I b : rest) = constants (I (a + b) : rest)
+        constants others = others
+
+getPluses :: KnOp -> [KnOp]
+getPluses (a `Add` b) = getPluses a ++ getPluses b
+getPluses otherwise = pure otherwise
+
+offset :: (KnOp -> Maybe t) -> (Type -> Type -> t -> Maybe t) -> KnOp -> [KnConstraint] -> Maybe t -> Maybe t
+offset _go _crc _want kn_givens found@Just{} = found
+offset go crc want kn_givens _ = do let knowns = (\(_,_,c)->c) <$> kn_givens
+                                        exploded = (pluses &&& id) <$> knowns
+                                        interesting = mapMaybe (\(summands, entire) ->
+                                                                  case (Data.Set.toList summands, Data.Set.toList (pluses want)) of
+                                                                    ([I n,C sty], [C wty]) | sty == wty -> Just (entire, n)
+                                                                    ((I n : srest), (I m : wrest)) | srest == wrest -> Just (entire, n - m)
+                                                                    _ -> Nothing
+                                                               ) exploded
+                                    ((h, corr):_) <- pure interesting
+                                    let x = h `Sub` I corr
+                                    ev <- go x
+                                    crc (reifyOp x) (reifyOp want) ev
+
+
 -- | Classes and instances from "GHC.TypeLits.KnownNat"
 data KnownNatDefs = KnownNatDefs
   { knAddDFunId :: (Class,DFunId) -- ^ KnownNatAdd class and its only instance
+  , knSubDFunId :: (Class,DFunId) -- ^ KnownNatSubtract class and its only instance
   , knMulDFunId :: (Class,DFunId) -- ^ KnownNatMul class and its only instance
   , knExpDFunId :: (Class,DFunId) -- ^ KnownNatPow class and its only instance
   }
 
 instance Outputable KnownNatDefs where
   ppr d = text "{" <+> ppr (knAddDFunId d) <+>
+          text "," <+> ppr (knSubDFunId d) <+>
           text "," <+> ppr (knMulDFunId d) <+>
           text "," <+> ppr (knExpDFunId d) <+>
           text "}"
@@ -101,8 +141,10 @@ data KnOp
   = I Integer
   | C CType
   | Add KnOp KnOp
+  | Sub KnOp KnOp
   | Mul KnOp KnOp
   | Exp KnOp KnOp
+ deriving (Eq, Ord)
 
 newtype CType = CType Type
   deriving Outputable
@@ -110,10 +152,14 @@ newtype CType = CType Type
 instance Eq CType where
   (==) = coerce eqType
 
+instance Ord CType where
+  compare = coerce nonDetCmpType
+
 instance Outputable KnOp where
   ppr (I i)     = integer i
   ppr (C v)     = ppr v
   ppr (Add x y) = parens $ ppr x <+> text "+" <+> ppr y
+  ppr (Sub x y) = parens $ ppr x <+> text "-" <+> ppr y
   ppr (Mul x y) = parens $ ppr x <+> text "*" <+> ppr y
   ppr (Exp x y) = parens $ ppr x <+> text "^" <+> ppr y
 
@@ -178,7 +224,7 @@ solveKnownNat defs  givens  _deriveds wanteds = do
       let kn_map = mapMaybe toKnEntry kn_givens
       -- Try to solve the wanted KnownNat constraints given the [G]iven
       -- KnownNat constraints
-      let solved = mapMaybe (constraintToEvTerm defs kn_map) kn_wanteds
+      let solved = mapMaybe (constraintToEvTerm defs kn_givens kn_map) kn_wanteds
       return (TcPluginOk solved [])
 
 -- | Get the KnownNat constraints
@@ -216,9 +262,10 @@ lookupKnownNatDefs :: TcPluginM KnownNatDefs
 lookupKnownNatDefs = do
     md     <- lookupModule myModule myPackage
     addDF  <- look md "KnownNatAdd"
+    subDF  <- look md "KnownNatSubtract"
     mulDF  <- look md "KnownNatMul"
     expDF  <- look md "KnownNatExp"
-    return $ KnownNatDefs addDF mulDF expDF
+    return $ KnownNatDefs addDF subDF mulDF expDF
   where
     look md s = do
       nm   <- lookupName md (mkTcOcc s)
@@ -241,19 +288,27 @@ reifyOp :: KnOp -> Type
 reifyOp (I i)          = mkNumLitTy i
 reifyOp (C (CType ty)) = ty
 reifyOp (Add x y)      = mkTyConApp typeNatAddTyCon $ reifyOp <$> [x, y]
+reifyOp (Sub x (I n)) | n < 0 = mkTyConApp typeNatAddTyCon $ reifyOp <$> [x, (I $ -n)]
+reifyOp (Sub x y)      = mkTyConApp typeNatSubTyCon $ reifyOp <$> [x, y]
 reifyOp (Mul x y)      = mkTyConApp typeNatMulTyCon $ reifyOp <$> [x, y]
 reifyOp (Exp x y)      = mkTyConApp typeNatExpTyCon $ reifyOp <$> [x, y]
 
 -- | Try to create evidence for a wanted constraint
-constraintToEvTerm :: KnownNatDefs -> [(CType,EvVar)] -> KnConstraint
+constraintToEvTerm :: KnownNatDefs -> [KnConstraint] -> [(CType,EvVar)] -> KnConstraint
                    -> Maybe (EvTerm,Ct)
-constraintToEvTerm defs kn_map (ct,cls,op) = (,ct) <$> go op
+constraintToEvTerm defs kn_givens kn_map (ct,cls,op) = (,ct) <$> go op
   where
+    isKnOp want (_,_,knOp) = want == knOp
+    knCoercion = makeKnCoercion cls
+    go want | ((ct,_,_) : _) <- filter (isKnOp want) kn_givens = pure . EvId . ctev_evar . ctEvidence $ ct
     go (I i)  = makeLitDict cls (mkNumLitTy i) i
-    go (C ty) = EvId <$> lookup ty kn_map
+    go op@(C ty) = offset go knCoercion op kn_givens $ EvId <$> lookup ty kn_map
+    go clpx | found@Just{} <- offset go knCoercion clpx kn_givens Nothing = found
     go e = do
       let (x,y,df) = case e of
             Add x' y' -> (x',y',knAddDFunId defs)
+            Sub x' (I n) | n < 0 -> (x',(I $ -n),knAddDFunId defs)
+            Sub x' y' -> (x',y',knSubDFunId defs)
             Mul x' y' -> (x',y',knMulDFunId defs)
             Exp x' y' -> (x',y',knExpDFunId defs)
             _ -> panicDoc "GHC.TypeLits.KnownNat.Solver: not an op" (ppr e)
@@ -316,6 +371,28 @@ makeOpDict (opCls,dfid) knCls x y z xEv yEv
   = Just ev_tm
   | otherwise
   = Nothing
+
+makeKnCoercion :: Class          -- ^ KnownNat class
+               -> Type           -- ^ Type of the argument
+               -> Type           -- ^ Type of the result
+               -> EvTerm         -- ^ KnownNat dictionary for the argument
+               -> Maybe EvTerm
+makeKnCoercion knCls x z xEv
+  | Just (_, kn_co_dict_z) <- tcInstNewTyCon_maybe (classTyCon knCls) [z]
+    -- KnownNat z ~ SNat z
+  , [ kn_meth ] <- classMethods knCls
+  , Just kn_tcRep <- tyConAppTyCon_maybe -- SNat
+                      $ funResultTy      -- SNat n
+                      $ dropForAlls      -- KnownNat n => SNat n
+                      $ idType kn_meth   -- forall n. KnownNat n => SNat n
+  , Just (_, kn_co_rep_z) <- tcInstNewTyCon_maybe kn_tcRep [z]
+    -- SNat z ~ Integer
+  , Just (_, kn_co_rep_x) <- tcInstNewTyCon_maybe kn_tcRep [x]
+    -- Integer ~ SNat x
+  , Just (_, kn_co_dict_x) <- tcInstNewTyCon_maybe (classTyCon knCls) [x]
+    -- SNat x ~ KnownNat x
+  = Just . mkEvCast xEv $ (kn_co_dict_x `mkTcTransCo` kn_co_rep_x) `mkTcTransCo` mkTcSymCo (kn_co_dict_z `mkTcTransCo` kn_co_rep_z)
+  | otherwise = Nothing
 
 -- | THIS CODE IS COPIED FROM:
 -- https://github.com/ghc/ghc/blob/8035d1a5dc7290e8d3d61446ee4861e0b460214e/compiler/typecheck/TcInteract.hs#L1973

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE DataKinds, ScopedTypeVariables, TypeOperators, TypeApplications #-}
+{-# LANGUAGE DataKinds, FlexibleContexts, KindSignatures, ScopedTypeVariables
+           , TypeOperators, TypeApplications, TypeFamilies, TypeFamilyDependencies #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}
 
@@ -6,6 +7,8 @@ import Data.Proxy
 import GHC.TypeLits
 import Test.Tasty
 import Test.Tasty.HUnit
+import Data.Type.Equality ((:~:)(..))
+import Unsafe.Coerce (unsafeCoerce)
 
 test1 :: forall n . KnownNat n => Proxy n -> Integer
 test1 _ = natVal (Proxy :: Proxy n) + natVal (Proxy :: Proxy (n+2))
@@ -27,6 +30,26 @@ test6 _ _ = natVal (Proxy :: Proxy ((n^m)+(n*m)))
 
 test11 :: forall m . (KnownNat m) => Proxy m -> Integer
 test11 _ = natVal (Proxy @ (m*m))
+
+test12 :: forall m . (KnownNat (m+1)) => Proxy m -> Integer
+test12 = natVal
+
+test13 :: forall m . (KnownNat (m+3)) => Proxy m -> Integer
+test13 = natVal
+
+test14 :: forall m . (KnownNat (4+m)) => Proxy (7+m) -> Integer
+test14 = natVal
+
+type family Foo (m :: Nat) = (result :: Nat) | result -> m
+test15 :: KnownNat (4 + Foo 1) => Proxy (Foo 1) -> Proxy (4 + Foo 1) -> Integer
+test15 _ _ = natVal (Proxy @ (Foo 1 + 7))
+test15' :: Integer
+test15' = case unsafeCoerce Refl :: 1 :~: Foo 1 of Refl -> test15 (Proxy @ (Foo 1)) (Proxy @ (4 + Foo 1))
+
+test16 :: KnownNat (4 + Foo 1 + Foo 1) => Proxy (Foo 1) -> Proxy (4 + Foo 1 + Foo 1) -> Integer
+test16 _ _ = natVal (Proxy @ (Foo 1 + 7 + Foo 1))
+test16' :: Integer
+test16' = case unsafeCoerce Refl :: 1 :~: Foo 1 of Refl -> test16 (Proxy @ (Foo 1)) (Proxy @ (4 + Foo 1 + Foo 1))
 
 tests :: TestTree
 tests = testGroup "ghc-typelits-natnormalise"
@@ -57,6 +80,24 @@ tests = testGroup "ghc-typelits-natnormalise"
     [ testCase "KnownNat m => KnownNat (m*m); @ 5" $
       show (test11 (Proxy @ 5)) @?=
       "25"
+    , testCase "KnownNat (m+1) => KnownNat m; @ m ~ 5" $
+      show (test12 (Proxy @ 5)) @?=
+      "5"
+    , testCase "KnownNat (m+1) => KnownNat m; @ m ~ 0" $
+      show (test12 (Proxy @ 0)) @?=
+      "0"
+    , testCase "KnownNat (m+3) => KnownNat m; @ m ~ 0" $
+      show (test13 (Proxy @ 0)) @?=
+      "0"
+    , testCase "KnownNat (4+m) => KnownNat (7+m); @ m ~ 1" $
+      show (test14 (Proxy @ 8)) @?=
+      "8"
+    , testCase "KnownNat (4 + Foo 1) => KnownNat (Foo 1 + 7); @ Foo 1 ~ 1" $
+      show test15' @?=
+      "8"
+    , testCase "KnownNat (4 + Foo 1 + Foo 1) => KnownNat (Foo 1 + 7 + Foo 1); @ Foo 1 ~ 1" $
+      show test16' @?=
+      "9"
     ]
   ]
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -41,15 +41,14 @@ test14 :: forall m . (KnownNat (4+m)) => Proxy (7+m) -> Integer
 test14 = natVal
 
 type family Foo (m :: Nat) = (result :: Nat) | result -> m
+fakeFooEvidence :: 1 :~: Foo 1
+fakeFooEvidence = unsafeCoerce Refl
+
 test15 :: KnownNat (4 + Foo 1) => Proxy (Foo 1) -> Proxy (4 + Foo 1) -> Integer
 test15 _ _ = natVal (Proxy @ (Foo 1 + 7))
-test15' :: Integer
-test15' = case unsafeCoerce Refl :: 1 :~: Foo 1 of Refl -> test15 (Proxy @ (Foo 1)) (Proxy @ (4 + Foo 1))
 
 test16 :: KnownNat (4 + Foo 1 + Foo 1) => Proxy (Foo 1) -> Proxy (4 + Foo 1 + Foo 1) -> Integer
 test16 _ _ = natVal (Proxy @ (Foo 1 + 7 + Foo 1))
-test16' :: Integer
-test16' = case unsafeCoerce Refl :: 1 :~: Foo 1 of Refl -> test16 (Proxy @ (Foo 1)) (Proxy @ (4 + Foo 1 + Foo 1))
 
 tests :: TestTree
 tests = testGroup "ghc-typelits-natnormalise"
@@ -93,10 +92,12 @@ tests = testGroup "ghc-typelits-natnormalise"
       show (test14 (Proxy @ 8)) @?=
       "8"
     , testCase "KnownNat (4 + Foo 1) => KnownNat (Foo 1 + 7); @ Foo 1 ~ 1" $
-      show test15' @?=
+      (case fakeFooEvidence of
+          Refl -> show $ test15 (Proxy @ (Foo 1)) (Proxy @ (4 + Foo 1))) @?=
       "8"
     , testCase "KnownNat (4 + Foo 1 + Foo 1) => KnownNat (Foo 1 + 7 + Foo 1); @ Foo 1 ~ 1" $
-      show test16' @?=
+      (case fakeFooEvidence of
+          Refl -> show $ test16 (Proxy @ (Foo 1)) (Proxy @ (4 + Foo 1 + Foo 1))) @?=
       "9"
     ]
   ]

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -50,6 +50,10 @@ test15 _ _ = natVal (Proxy @ (Foo 1 + 7))
 test16 :: KnownNat (4 + Foo 1 + Foo 1) => Proxy (Foo 1) -> Proxy (4 + Foo 1 + Foo 1) -> Integer
 test16 _ _ = natVal (Proxy @ (Foo 1 + 7 + Foo 1))
 
+test17 :: KnownNat (4 + 2 * Foo 1 + Foo 1) => Proxy (Foo 1) -> Proxy (4 + 2 * Foo 1 + Foo 1) -> Integer
+test17 _ _ = natVal (Proxy @ (2 * Foo 1 + 7 + Foo 1))
+
+
 tests :: TestTree
 tests = testGroup "ghc-typelits-natnormalise"
   [ testGroup "Basic functionality"
@@ -99,6 +103,10 @@ tests = testGroup "ghc-typelits-natnormalise"
       (case fakeFooEvidence of
           Refl -> show $ test16 (Proxy @ (Foo 1)) (Proxy @ (4 + Foo 1 + Foo 1))) @?=
       "9"
+    , testCase "KnownNat (4 + 2 * Foo 1 + Foo 1) => KnownNat (2 * Foo 1 + 7 + Foo 1); @ Foo 1 ~ 1" $
+      (case fakeFooEvidence of
+          Refl -> show $ test17 (Proxy @ (Foo 1)) (Proxy @ (4 + 2 * Foo 1 + Foo 1))) @?=
+      "10"
     ]
   ]
 


### PR DESCRIPTION
*Please review.* I took the liberty to squash all my intermediate commits, if you prefer piecemeal, I have a tag and can restore.

This can now:
- figure out terms that are off by a constant amount
- modulo `(+)` associativity and commutativity

Coding Style
===========

Somewhat chaotic, but the `_x`, `_y`, `_z` conventions are probably worth adapting in other parts.
Feedback welcome!

Check:
- [ ] variable naming
- [ ] usage of `(.)` and point-free

*TODOs*
========
- [x] Undo some `.cabal` file changes
- [ ] Check correct use of extensions
- [x] More comments
- [ ] `Mul`-commutativity and solving
- [x] Comments/Haddocks
- [x] More tests
- [x] reactivate `-Werror`
- [ ] update README