### PR TITLE
Implement support for unary arithmetic functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for the [`ghc-typelits-knownnat`](http://hackage.haskell.org/package/ghc-typelits-knownnat) package
 
+## 0.2.4
+* New features:
+  * Derive constraints for unary functions via a `KnownNat1` instance.
+
 ## 0.2.3 *January 15th 2017*
 * Solve normalised literal constraints, i.e.:
   * `KnownNat (((addrSize + 1) - (addrSize - 1))) ~ KnownNat 2`

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 Copyright (c) 2015-2016, University of Twente,
-              2017, QBayLogic
+              2017, QBayLogic,
+              2017, Google Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/ghc-typelits-knownnat.cabal
+++ b/ghc-typelits-knownnat.cabal
@@ -1,5 +1,5 @@
 name:                ghc-typelits-knownnat
-version:             0.2.3
+version:             0.2.4
 synopsis:            Derive KnownNat constraints from other KnownNat constraints
 description:
   A type checker plugin for GHC that can derive \"complex\" @KnownNat@

--- a/ghc-typelits-knownnat.cabal
+++ b/ghc-typelits-knownnat.cabal
@@ -104,7 +104,8 @@ test-suite test-ghc-typelits-knownnat
                        ghc-typelits-natnormalise >= 0.5   && <0.6,
                        singletons                >= 2.2   && <3.0,
                        tasty                     >= 0.10,
-                       tasty-hunit               >= 0.9
+                       tasty-hunit               >= 0.9,
+                       tasty-quickcheck          >= 0.8
   hs-source-dirs:      tests
   default-language:    Haskell2010
   other-extensions:    DataKinds

--- a/src/GHC/TypeLits/KnownNat.hs
+++ b/src/GHC/TypeLits/KnownNat.hs
@@ -106,6 +106,7 @@ module GHC.TypeLits.KnownNat
   ( -- * Singleton natural number
     SNatKn (..)
     -- * Constraint-level arithmetic classes
+  , KnownNat1 (..)
   , KnownNat2 (..)
   , KnownNat3 (..)
     -- * Template Haskell helper
@@ -124,6 +125,15 @@ import GHC.TypeLits.KnownNat.TH
 
 -- | Singleton natural number (represented by an integer)
 newtype SNatKn (n :: Nat) = SNatKn Integer
+
+-- | Class for arithmetic functions with /one/ argument.
+--
+-- The 'Symbol' /f/ must correspond to the fully qualified name of the
+-- type-level operation. Use 'nameToSymbol' to get the fully qualified
+-- TH Name as a 'Symbol'
+class KnownNat1 (f :: Symbol) (a :: Nat) where
+  type KnownNatF1 f :: Nat ~> Nat
+  natSing1 :: SNatKn (KnownNatF1 f @@ a)
 
 -- | Class for arithmetic functions with /two/ arguments.
 --

--- a/src/GHC/TypeLits/KnownNat/Solver.hs
+++ b/src/GHC/TypeLits/KnownNat/Solver.hs
@@ -270,9 +270,11 @@ normaliseSOP = reifySOP . normaliseNat
 lookupKnownNatDefs :: TcPluginM KnownNatDefs
 lookupKnownNatDefs = do
     md     <- lookupModule myModule myPackage
+    kn1C   <- look md "KnownNat1"
     kn2C   <- look md "KnownNat2"
     kn3C   <- look md "KnownNat3"
-    return $ (\case { 2 -> Just kn2C
+    return $ (\case { 1 -> Just kn1C
+                    ; 2 -> Just kn2C
                     ; 3 -> Just kn3C
                     ; _ -> Nothing
                     })

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -11,9 +11,14 @@ import Data.Type.Equality ((:~:)(..))
 import GHC.TypeLits
 import Test.Tasty
 import Test.Tasty.HUnit
+import Test.Tasty.QuickCheck
 import Unsafe.Coerce (unsafeCoerce)
 
 import TestFunctions
+
+logT :: Integer -> Integer
+logT n = withNat n $ \(Proxy :: Proxy n) ->
+                           natVal (Proxy :: Proxy (Log n))
 
 test1 :: forall n . KnownNat n => Proxy n -> Integer
 test1 _ = natVal (Proxy :: Proxy n) + natVal (Proxy :: Proxy (n+2))
@@ -191,7 +196,9 @@ tests = testGroup "ghc-typelits-natnormalise"
     , testCase "SNat ((addrSize + 1) - (addrSize - 1)) = SNat 2" $
       show (test23 (SNat @ 8)) @?=
       "2"
-    ]
+    ],
+    testGroup "QuickCheck"
+    [ testProperty "logT = logInt" $ (\a -> (a > 0) ==> (logT a == logInt a)) ]
   ]
 
 main :: IO ()


### PR DESCRIPTION
I wanted a type level logarithm for some experiments, so I've implemented support for unary functions here. Previously, one could make a two-argument function that just didn't make use of its argument, but it looks messier than directly implementing one-argument function.

Also, I added a proptest for it (using QuickCheck) since that seemed easiest, and then some other proptests while I was trying to debug... Whether you want to keep the tests that way is up to you.