### PR TITLE
Restrict singletons dependency to <2.4

### DIFF
--- a/ghc-typelits-knownnat.cabal
+++ b/ghc-typelits-knownnat.cabal
@@ -85,7 +85,7 @@ library
                        ghc                       >= 8.0.1    && <8.4,
                        ghc-tcplugins-extra       >= 0.2,
                        ghc-typelits-natnormalise >= 0.5.2    && <0.6,
-                       singletons                >= 2.2      && <3.0,
+                       singletons                >= 2.2      && <2.4,
                        transformers              >= 0.5.2.0  && <0.6,
                        template-haskell          >= 2.11.0.0 && <2.13
   hs-source-dirs:      src
@@ -102,7 +102,7 @@ test-suite test-ghc-typelits-knownnat
   build-depends:       base                      >= 4.8   && <5,
                        ghc-typelits-knownnat     >= 0.1,
                        ghc-typelits-natnormalise >= 0.5   && <0.6,
-                       singletons                >= 2.2   && <3.0,
+                       singletons                >= 2.2   && <2.4,
                        tasty                     >= 0.10,
                        tasty-hunit               >= 0.9,
                        tasty-quickcheck          >= 0.8


### PR DESCRIPTION
Not really necessary right now, but singletons 2.4 (which will be in future stackage snapshots) changes the defunctionalized symbols in Data.Promotion.Prelude.Num [here](https://github.com/goldfirere/singletons/commit/65e04b26806178ff76c96573357296429871a668) and [here](https://github.com/goldfirere/singletons/commit/58c66080c2e5264bb62c607525682e4553fb5d6e).