### PR TITLE
Update template-haskell bounds to work with GHC-8.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,10 @@ before_cache:
 
 matrix:
   include:
-    - compiler: "ghc-8.6.4"
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.4], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.8.1"
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.0,ghc-8.8.1], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.6.5"
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.5], sources: [hvr-ghc]}}
     - compiler: "ghc-8.4.4"
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.4.4], sources: [hvr-ghc]}}
     - compiler: "ghc-8.2.2"

--- a/ghc-typelits-knownnat.cabal
+++ b/ghc-typelits-knownnat.cabal
@@ -91,7 +91,7 @@ library
                        ghc-tcplugins-extra       >= 0.3,
                        ghc-typelits-natnormalise >= 0.6      && <0.8,
                        transformers              >= 0.5.2.0  && <0.6,
-                       template-haskell          >= 2.11.0.0 && <2.15
+                       template-haskell          >= 2.11.0.0 && <2.16
   hs-source-dirs:      src
   default-language:    Haskell2010
   if flag(deverror)


### PR DESCRIPTION
After merging this we should make the same change to the cabal file on hackage