### PR TITLE
Only solve variable offset when we have a [G]iven knownnat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.1
 * Fix [#29](https://github.com/clash-lang/ghc-typelits-knownnat/issues/29)
+* Fix [#30](https://github.com/clash-lang/ghc-typelits-knownnat/issues/30)
 
 ## 0.7 *August 26th 2018*
 * Solve "known" type-level Booleans, also inside `If` (GHC 8.6+)


### PR DESCRIPTION
Fixes #30
Fixes clash-lang/clash-compiler#608