### PR TITLE
Use shiftL(Natural/Integer) instead of Bits.shiftL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog for the [`ghc-typelits-knownnat`](http://hackage.haskell.org/package/ghc-typelits-knownnat) package
 
+## 0.7.3 *July 25th 2020*
+* Fix https://github.com/clash-lang/clash-compiler/issues/1454
+
 ## 0.7.2 *February 6th 2020*
  * Add support for GHC 8.10.0-alpha2
 

--- a/ghc-typelits-knownnat.cabal
+++ b/ghc-typelits-knownnat.cabal
@@ -1,5 +1,5 @@
 name:                ghc-typelits-knownnat
-version:             0.7.2
+version:             0.7.3
 synopsis:            Derive KnownNat constraints from other KnownNat constraints
 description:
   A type checker plugin for GHC that can derive \"complex\" @KnownNat@
@@ -98,6 +98,8 @@ library
     ghc-options:       -Wall -Werror
   else
     ghc-options:       -Wall
+  if impl(ghc < 8.2)
+    build-depends:     integer-gmp               >= 0.5.1.0
 
 test-suite test-ghc-typelits-knownnat
   type:                exitcode-stdio-1.0


### PR DESCRIPTION
For some bizarre reason, which I cannot reproduce, the set of GHC optimizations that Clash picks results in a weird specialization
of the `natSing2` implementation for `GHC.TypeNats.^`, which is specialized to the `y` in `x ^ y` being a negative number.

This then causes the:

> shiftL x y = if y <= 0 then shiftLNatural x y else shiftRNatural x (negate y)

to pick the else branch, which in turn causes fast power-of-two calculation in `natSing2` to do  `1 shiftR y` instead of the intended `1 shiftL y`.

Anyhow... I don't know what's going on... This patch ensures we call `shiftLNatural` directly, since we know the exponent
never a negative number; and GHC won't be able to specialize.

Fixes https://github.com/clash-lang/clash-compiler/issues/1454