### PR TITLE
Don't look for offsets from constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog for the [`ghc-typelits-knownnat`](http://hackage.haskell.org/package/ghc-typelits-knownnat) package
 
+## 0.7.11
+* Fix infinite loop between plugin and solver pipeline
+
 ## 0.7.10 *November 14th 2023*
 * Work around [GHC issue 23109](https://gitlab.haskell.org/ghc/ghc/-/issues/23109)
 

--- a/ghc-typelits-knownnat.cabal
+++ b/ghc-typelits-knownnat.cabal
@@ -1,5 +1,5 @@
 name:                ghc-typelits-knownnat
-version:             0.7.10
+version:             0.7.11
 synopsis:            Derive KnownNat constraints from other KnownNat constraints
 description:
   A type checker plugin for GHC that can derive \"complex\" @KnownNat@

--- a/src-ghc-9.4/GHC/TypeLits/KnownNat/Solver.hs
+++ b/src-ghc-9.4/GHC/TypeLits/KnownNat/Solver.hs
@@ -493,6 +493,7 @@ constraintToEvTerm defs givens (ct,cls,op,orig) = do
     -- Find a known constraint for a wanted, so that (modulo normalization)
     -- the two are a constant offset apart.
     offset :: Type -> TcPluginM (Maybe (EvTerm,[Ct]))
+    offset LitTy{} = pure Nothing
     offset want = runMaybeT $ do
       let -- Get the knownnat contraints
           unKn ty' = case classifyPredType ty' of

--- a/src-pre-ghc-9.4/GHC/TypeLits/KnownNat/Solver.hs
+++ b/src-pre-ghc-9.4/GHC/TypeLits/KnownNat/Solver.hs
@@ -579,6 +579,7 @@ constraintToEvTerm defs givens (ct,cls,op,orig) = do
     -- Find a known constraint for a wanted, so that (modulo normalization)
     -- the two are a constant offset apart.
     offset :: Type -> TcPluginM (Maybe (EvTerm,[Ct]))
+    offset LitTy{} = pure Nothing
     offset want = runMaybeT $ do
       let -- Get the knownnat contraints
           unKn ty' = case classifyPredType ty' of


### PR DESCRIPTION
This introduces an infinite loop with the solver pipeline. i.e. when we have:

[G] x :: KnownNat 10
[W] KnownNat 4

we would produce

solved: x - y :: KnownNat 4
New wanted: y :: KnownNat 6

Then we would go to:

[G] x :: KnownNat 10
[W] KnownNat 6

and solve as:

solved: x - y :: KnownNat 6
new wanted: y :: KnownNat 4

And cycle....

Found when upgrading https://github.com/bittide/bittide-hardware/ to GHC 9.4. But it's hard to create a small reproducer, so there is no regression test.