### PR TITLE
Revert "Emit EqPred instead of IrredPred for KnownNat (-) on GHC 9.4+"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for the [`ghc-typelits-knownnat`](http://hackage.haskell.org/package/ghc-typelits-knownnat) package
 
+## Unreleased
+* Unfix -fdefer-type-errors regression as it caused more regressions
+
+## 0.8.2 *October 17th 2025*
+* Fix -fdefer-type-errors regression
+
 ## 0.8.1 *October 10th 2025*
 * Fix [#53](https://github.com/clash-lang/ghc-typelits-knownnat/issues/53) The plugin sometimes doesn't look through type aliases
 * Fix [#13](https://github.com/clash-lang/ghc-typelits-knownnat/issues/13) Type equality constraints aren't used by solver

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Changelog for the [`ghc-typelits-knownnat`](http://hackage.haskell.org/package/ghc-typelits-knownnat) package
 
-## 0.8.2 *October 17th 2025*
-* Fix -fdefer-type-errors regression
-
 ## 0.8.1 *October 10th 2025*
 * Fix [#53](https://github.com/clash-lang/ghc-typelits-knownnat/issues/53) The plugin sometimes doesn't look through type aliases
 * Fix [#13](https://github.com/clash-lang/ghc-typelits-knownnat/issues/13) Type equality constraints aren't used by solver

--- a/ghc-typelits-knownnat.cabal
+++ b/ghc-typelits-knownnat.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                ghc-typelits-knownnat
-version:             0.8.1
+version:             0.8.2
 synopsis:            Derive KnownNat constraints from other KnownNat constraints
 description:
   A type checker plugin for GHC that can derive \"complex\" @KnownNat@

--- a/ghc-typelits-knownnat.cabal
+++ b/ghc-typelits-knownnat.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                ghc-typelits-knownnat
-version:             0.8.2
+version:             0.8.1
 synopsis:            Derive KnownNat constraints from other KnownNat constraints
 description:
   A type checker plugin for GHC that can derive \"complex\" @KnownNat@

--- a/src/GHC/TypeLits/KnownNat.hs
+++ b/src/GHC/TypeLits/KnownNat.hs
@@ -134,10 +134,6 @@ import Data.Type.Bool
   ( If )
 import GHC.Exts
   ( Proxy# )
-#if __GLASGOW_HASKELL__ >= 904
-import GHC.Exts
-  ( Constraint )
-#endif
 import GHC.TypeLits
   ( Symbol )
 import GHC.TypeNats
@@ -210,11 +206,7 @@ instance (KnownNat a, KnownNat b) => KnownNat2 $(nameToSymbol ''(^)) a b where
   {-# NOINLINE natSing2 #-}
 
 -- | 'KnownNat2' instance for "GHC.TypeLits"' 'GHC.TypeLits.-'
-#if __GLASGOW_HASKELL__ >= 904
-instance (KnownNat a, KnownNat b, (b <= a) ~ (() :: Constraint)) => KnownNat2 $(nameToSymbol ''(-)) a b where
-#else
 instance (KnownNat a, KnownNat b, b <= a) => KnownNat2 $(nameToSymbol ''(-)) a b where
-#endif
   natSing2 = SNatKn (natVal (Proxy @a) - natVal (Proxy @b))
   {-# NOINLINE natSing2 #-}
 


### PR DESCRIPTION
Reverts clash-lang/ghc-typelits-knownnat#64

Fixes https://github.com/clash-lang/ghc-typelits-knownnat/issues/66